### PR TITLE
Added push to dockerhub and code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @neo4j-field/team-connectors

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,19 @@ jobs:
   push_to_registries:
     name: Push Docker image to multiple registries
     runs-on: ubuntu-latest
+    environment: Release
     permissions:
       packages: write
       contents: read
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
+
+      - name: Log in to the Docker Hub
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Log in to the Github Container Registry
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
@@ -27,12 +34,14 @@ jobs:
         uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175
         with:
           images: |
+            neo4j/bigquery-connector
             ghcr.io/${{ github.repository }}
 
       - name: Build and push Docker images
         uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825
         with:
           context: .
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/pattern_parser/__init__.py
+++ b/pattern_parser/__init__.py
@@ -5,10 +5,6 @@ __all__ = [
     "NodePattern",
     "EdgePattern",
     "parse_pattern",
-    "__version__",
-    "__author__",
 ]
-__author__ = "Neo4j"
-__version__ = "0.5.1"
 
 from .Pattern import Pattern, NodePattern, EdgePattern, parse_pattern

--- a/setup.py
+++ b/setup.py
@@ -13,15 +13,14 @@ setup(
 
     url="https://github.com/neo4j-field/bigquery-connector",
     author="Neo4j, Inc.",
-    author_email="dave.voutila@neo4j.com",
 
-    description="A connector for building a Neo4j Graph from Google BigQuery",
+    description="Google BigQuery connector for AuraDS & Neo4j with GDS",
     long_description=long_description,
     long_description_content_type="text/markdown",
 
     license="Apache License 2.0",
 
-    classifiers = [
+    classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",

--- a/templates/__init__.py
+++ b/templates/__init__.py
@@ -12,7 +12,7 @@ __all__ = [
     "__author__",
 ]
 __author__ = "Neo4j"
-__version__ = "0.5.1"
+__version__ = "0.6.0"
 
 from . import constants, util
 from .bq_client import BigQuerySource, BigQuerySink


### PR DESCRIPTION
This PR updates the release workflow to also push to docker hub with `linux/amd64` as an explicit platform. Also adds CODEOWNERS file.